### PR TITLE
fixed fullpath can be directory issue

### DIFF
--- a/src/Services/SearchRootResolver.cs
+++ b/src/Services/SearchRootResolver.cs
@@ -27,15 +27,9 @@ namespace InstaSearch.Services
             if (!string.IsNullOrEmpty(solutionPath))
             {
                 // Solution path can be pointing to a folder not just a .sln file in Open Folder scenario, so we need to check if it's a directory first
-                if (Directory.Exists(solutionPath))
-                {
-                    solutionDir = solutionPath; // Open Folder scenario where FullPath is a directory
-                }
-                else
-                {
-                    solutionDir = Path.GetDirectoryName(solutionPath);
-                }
-            
+                solutionDir = Directory.Exists(solutionPath)
+                    ? solutionPath // Open Folder scenario where FullPath is a directory
+                    : Path.GetDirectoryName(solutionPath);
                 // Try git repo root first (highest priority)
                 var gitRoot = FindGitRoot(solutionDir);
                 if (gitRoot != null)

--- a/src/Services/SearchRootResolver.cs
+++ b/src/Services/SearchRootResolver.cs
@@ -22,11 +22,21 @@ namespace InstaSearch.Services
             // Try to get the solution path first as it's needed for fallback
             Solution solution = await VS.Solutions.GetCurrentSolutionAsync();
             var solutionPath = solution?.FullPath;
-            var solutionDir = !string.IsNullOrEmpty(solutionPath) ? Path.GetDirectoryName(solutionPath) : null;
+            var solutionDir = string.Empty;
 
-            // Try git repo root first (highest priority)
-            if (!string.IsNullOrEmpty(solutionDir))
+            if (!string.IsNullOrEmpty(solutionPath))
             {
+                // Solution path can be pointing to a folder not just a .sln file in Open Folder scenario, so we need to check if it's a directory first
+                if (Directory.Exists(solutionPath))
+                {
+                    solutionDir = solutionPath; // Open Folder scenario where FullPath is a directory
+                }
+                else
+                {
+                    solutionDir = Path.GetDirectoryName(solutionPath);
+                }
+            
+                // Try git repo root first (highest priority)
                 var gitRoot = FindGitRoot(solutionDir);
                 if (gitRoot != null)
                 {


### PR DESCRIPTION
I created an issue earlier, last time I checked I could not find it. 

Here is a short description: 
Solution.FullPath can be a folder in case you opened a folder or in my case a CMakeLists.txt. In this case getting the parent directory with Path.GetDirectoryName gets the parent folder of the CMakeLists.txt which is the generally the wrong root for a CMake based project. 

The fix is very easy if the FullPath is a directory we just use it. Hope this fix fits. I would like to enjoy the results of it :)