### PR TITLE
Add column support and parenthesis syntax to jump syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ Filters can be combined freely: `service \src\ .cs -.designer.cs`
 
 ### Go-to-Line
 
-Append `:lineNumber` to your search query to jump directly to a specific line after opening the file. For example:
+Append a line number (and optional column) to jump directly to a specific location after opening. This syntax makes it easy to paste in a location from an error message. For example:
 
 - `program.cs:100` - Opens program.cs at line 100
 - `test*:25` - Opens the first matching file at line 25
+- `program.cs:100:13` - Line 100, column 13
+- `program.cs(100)` - Line 100
+- `program.cs(100,13)` - Line 100, column 13
 
 ### Keyboard Shortcuts
 

--- a/src/UI/FilesSelectedEventArgs.cs
+++ b/src/UI/FilesSelectedEventArgs.cs
@@ -6,9 +6,10 @@ namespace InstaSearch.UI
     /// <summary>
     /// Event args for when files are selected in the search dialog.
     /// </summary>
-    public class FilesSelectedEventArgs(IReadOnlyList<SearchResult> selectedFiles, int? lineNumber) : EventArgs
+    public class FilesSelectedEventArgs(IReadOnlyList<SearchResult> selectedFiles, int? lineNumber, int? columnNumber) : EventArgs
     {
         public IReadOnlyList<SearchResult> SelectedFiles { get; } = selectedFiles;
         public int? LineNumber { get; } = lineNumber;
+        public int? ColumnNumber { get; } = columnNumber;
     }
 }


### PR DESCRIPTION
One very common scenario for me when using file search is to take text from an error or diagnostic output and jump to the source of the problem. Clang emits filename.cpp:line:col, but Insta Search only currently supports :line suffix.

This PR extends the location support to also be able to navigate to an optional column.

Additionally, most Microsoft compilers emit locations with parenthesis, which aren't currently supported, so I also added support for 'file.cs(line,col)'.

Note: These changes were made with the assistance of AI, but were all fully understood and validated before submitting.

The one open question (beyond whether you want this functionality) is whether it's worth bolstering all the comments and documentation with the matrix of formats, as that gets a bit verbose for relatively minimal value.